### PR TITLE
Remove quotation mark that closed class= too early

### DIFF
--- a/resources/views/vendor/sidebar/group.blade.php
+++ b/resources/views/vendor/sidebar/group.blade.php
@@ -1,6 +1,6 @@
 <li class="sidebar-panel">
     @if($group->shouldShowHeading())
-        <a class="sidebar-title" @if(config('typicms.user.menus_'.$group->id.'_collapsed'))collapsed @endif" href="#{{ $group->id }}" data-toggle="collapse">
+        <a class="sidebar-title @if(config('typicms.user.menus_'.$group->id.'_collapsed'))collapsed @endif" href="#{{ $group->id }}" data-toggle="collapse">
             <div>{{ $group->name }}</div>
         </a>
     @endif


### PR DESCRIPTION
I found this while trying to diagnose the IE issue.