### PR TITLE
Ajout de la compatibilité MySQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ This kind of URLs are managed by the CMS:
 ## Requirements
 
 - PHP >= 7.0.0
+- MySQL 5.7
 - OpenSSL PHP Extension
 - PDO PHP Extension
 - Mbstring PHP Extension


### PR DESCRIPTION
N'est compatible qu'avec MySQL 5.7. Ne fonctionne pas sur MariaDb à cause de l'utilisation de spatie/laravel-translatable.